### PR TITLE
fix sorting in history

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -34,7 +34,8 @@ export default function Command(
   const { push } = useNavigation();
 
   useEffect(() => {
-    setRenderHistorySorted((history || []).sort());
+    const currentHistory = history || [];
+    setRenderHistorySorted([...currentHistory].sort());
   }, [history]);
 
   const updateHistory = (expression: string) => {


### PR DESCRIPTION
This should fix the sorting problem.

This is a general fix not related to the `ESC` situation. I created it separately so that, regardless of the decision with `ESC`, you can integrate it.